### PR TITLE
Remove Upload Artifact Step in Workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,9 +20,3 @@ jobs:
 
       - name: Build Site
         run: pnpm build
-
-      - name: Upload Artifact
-        uses: actions/upload-artifact@v4.6.2
-        with:
-          name: site
-          path: dist


### PR DESCRIPTION
This pull request resolves #453 by removing the "Upload Artifact" step from the `build` workflow.