### PR TITLE
Add Prettier Plugin for Organizing Imports

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,6 +1,10 @@
 {
   "printWidth": 100,
-  "plugins": ["prettier-plugin-astro", "prettier-plugin-tailwindcss"],
+  "plugins": [
+    "prettier-plugin-astro",
+    "prettier-plugin-organize-imports",
+    "prettier-plugin-tailwindcss"
+  ],
   "overrides": [
     {
       "files": "*.astro",

--- a/astro.config.ts
+++ b/astro.config.ts
@@ -1,11 +1,11 @@
+import mdx from "@astrojs/mdx";
+import sitemap from "@astrojs/sitemap";
+import tailwind from "@astrojs/tailwind";
+import icon from "astro-icon";
 import { defineConfig } from "astro/config";
 import fs from "fs";
-import mdx from "@astrojs/mdx";
-import tailwind from "@astrojs/tailwind";
-import sitemap from "@astrojs/sitemap";
-import icon from "astro-icon";
-import remarkUnwrapImages from "remark-unwrap-images";
 import rehypeExternalLinks from "rehype-external-links";
+import remarkUnwrapImages from "remark-unwrap-images";
 
 // https://astro.build/config
 export default defineConfig({

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "postcss-import": "^16.1.1",
     "prettier": "^3.6.2",
     "prettier-plugin-astro": "0.14.1",
+    "prettier-plugin-organize-imports": "^4.2.0",
     "prettier-plugin-tailwindcss": "^0.6.14",
     "reading-time": "^1.5.0",
     "remark-unwrap-images": "^4.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -114,9 +114,12 @@ importers:
       prettier-plugin-astro:
         specifier: 0.14.1
         version: 0.14.1
+      prettier-plugin-organize-imports:
+        specifier: ^4.2.0
+        version: 4.2.0(prettier@3.6.2)(typescript@5.8.3)
       prettier-plugin-tailwindcss:
         specifier: ^0.6.14
-        version: 0.6.14(prettier-plugin-astro@0.14.1)(prettier@3.6.2)
+        version: 0.6.14(prettier-plugin-astro@0.14.1)(prettier-plugin-organize-imports@4.2.0(prettier@3.6.2)(typescript@5.8.3))(prettier@3.6.2)
       reading-time:
         specifier: ^1.5.0
         version: 1.5.0
@@ -3317,6 +3320,16 @@ packages:
   prettier-plugin-astro@0.14.1:
     resolution: {integrity: sha512-RiBETaaP9veVstE4vUwSIcdATj6dKmXljouXc/DDNwBSPTp8FRkLGDSGFClKsAFeeg+13SB0Z1JZvbD76bigJw==}
     engines: {node: ^14.15.0 || >=16.0.0}
+
+  prettier-plugin-organize-imports@4.2.0:
+    resolution: {integrity: sha512-Zdy27UhlmyvATZi67BTnLcKTo8fm6Oik59Sz6H64PgZJVs6NJpPD1mT240mmJn62c98/QaL+r3kx9Q3gRpDajg==}
+    peerDependencies:
+      prettier: '>=2.0'
+      typescript: '>=2.9'
+      vue-tsc: ^2.1.0 || 3
+    peerDependenciesMeta:
+      vue-tsc:
+        optional: true
 
   prettier-plugin-tailwindcss@0.6.14:
     resolution: {integrity: sha512-pi2e/+ZygeIqntN+vC573BcW5Cve8zUB0SSAGxqpB4f96boZF4M3phPVoOFCeypwkpRYdi7+jQ5YJJUwrkGUAg==}
@@ -8073,11 +8086,17 @@ snapshots:
       prettier: 3.6.2
       sass-formatter: 0.7.9
 
-  prettier-plugin-tailwindcss@0.6.14(prettier-plugin-astro@0.14.1)(prettier@3.6.2):
+  prettier-plugin-organize-imports@4.2.0(prettier@3.6.2)(typescript@5.8.3):
+    dependencies:
+      prettier: 3.6.2
+      typescript: 5.8.3
+
+  prettier-plugin-tailwindcss@0.6.14(prettier-plugin-astro@0.14.1)(prettier-plugin-organize-imports@4.2.0(prettier@3.6.2)(typescript@5.8.3))(prettier@3.6.2):
     dependencies:
       prettier: 3.6.2
     optionalDependencies:
       prettier-plugin-astro: 0.14.1
+      prettier-plugin-organize-imports: 4.2.0(prettier@3.6.2)(typescript@5.8.3)
 
   prettier@2.8.7:
     optional: true

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -1,4 +1,4 @@
-import { z, defineCollection } from "astro:content";
+import { defineCollection, z } from "astro:content";
 
 function removeDupsAndLowerCase(array: string[]) {
   if (!array.length) return array;

--- a/src/pages/og-image/[slug].png.ts
+++ b/src/pages/og-image/[slug].png.ts
@@ -1,13 +1,13 @@
+import { siteConfig } from "@/site-config";
+import { getAllPosts, getFormattedDate } from "@/utils";
+import { Resvg } from "@resvg/resvg-js";
 import type { APIContext, GetStaticPaths } from "astro";
 import { getEntryBySlug } from "astro:content";
 import satori, { type SatoriOptions } from "satori";
 import { html } from "satori-html";
-import { Resvg } from "@resvg/resvg-js";
-import { siteConfig } from "@/site-config";
-import { getAllPosts, getFormattedDate } from "@/utils";
 
-import RobotoMono from "@/assets/roboto-mono-regular.ttf";
 import RobotoMonoBold from "@/assets/roboto-mono-700.ttf";
+import RobotoMono from "@/assets/roboto-mono-regular.ttf";
 
 const ogOptions: SatoriOptions = {
   width: 1200,

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -1,6 +1,6 @@
-import rss from "@astrojs/rss";
 import { siteConfig } from "@/site-config";
 import { getAllPosts } from "@/utils";
+import rss from "@astrojs/rss";
 
 export const GET = async () => {
   const posts = await getAllPosts();

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,6 +1,6 @@
 export { getFormattedDate } from "./date";
-export { elementHasClass, toggleClass, rootHasDarkClass } from "./domElement";
-export { getAllPosts, sortMDByDate, getUniqueTags, getUniqueTagsWithCount } from "./post";
+export { elementHasClass, rootHasDarkClass, toggleClass } from "./domElement";
 export { generateToc } from "./generateToc";
 export type { TocItem } from "./generateToc";
+export { getAllPosts, getUniqueTags, getUniqueTagsWithCount, sortMDByDate } from "./post";
 export { getWebmentionsForUrl } from "./webmentions";

--- a/src/utils/webmentions.ts
+++ b/src/utils/webmentions.ts
@@ -1,5 +1,5 @@
+import type { WebmentionsCache, WebmentionsChildren, WebmentionsFeed } from "@/types";
 import * as fs from "node:fs";
-import type { WebmentionsFeed, WebmentionsCache, WebmentionsChildren } from "@/types";
 
 const DOMAIN = import.meta.env.SITE;
 const API_TOKEN = import.meta.env.WEBMENTION_API_KEY;


### PR DESCRIPTION
This pull request resolves #542 by adding [prettier-plugin-organize-imports](https://www.npmjs.com/package/prettier-plugin-organize-imports) to this project. This change also fixes formatting by organizing imports according to the plugin's rules.