### PR TITLE
Approve `unrs-resolver` Built Dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,8 @@
   "pnpm": {
     "onlyBuiltDependencies": [
       "esbuild",
-      "sharp"
+      "sharp",
+      "unrs-resolver"
     ]
   }
 }


### PR DESCRIPTION
This pull request resolves #545 by adding `unrs-resolver` to the PNPM only built dependencies list.