### PR TITLE
Lock pnpm to Version 10

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -14,6 +14,8 @@ jobs:
 
       - name: Setup pnpm
         uses: threeal/setup-pnpm-action@v1.0.0
+        with:
+          version: 10.33.4
 
       - name: Install Dependencies
         run: pnpm install

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,6 +14,8 @@ jobs:
 
       - name: Setup pnpm
         uses: threeal/setup-pnpm-action@v1.0.0
+        with:
+          version: 10.33.4
 
       - name: Install Dependencies
         run: pnpm install

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "tailwindcss": "^3.4.18",
     "typescript": "^5.8.3"
   },
+  "packageManager": "pnpm@10.33.4",
   "pnpm": {
     "onlyBuiltDependencies": [
       "esbuild",


### PR DESCRIPTION
This pull request resolves #629 by locking the pnpm version used in this project to version 10.33.4 in both the GitHub Actions workflows and `package.json`.