### PR TITLE
Bump pnpm to version 10.34.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "tailwindcss": "^3.4.18",
     "typescript": "^5.8.3"
   },
-  "packageManager": "pnpm@10.33.4",
+  "packageManager": "pnpm@10.34.4",
   "pnpm": {
     "onlyBuiltDependencies": [
       "esbuild",


### PR DESCRIPTION
This pull request bumps pnpm to version [10.34.4](https://github.com/pnpm/pnpm/releases/tag/v10.34.4).