### PR TITLE
Move built dependencies config to pnpm-workspace.yaml

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,12 +56,5 @@
     "tailwindcss": "^3.4.18",
     "typescript": "^5.8.3"
   },
-  "packageManager": "pnpm@10.34.4",
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "esbuild",
-      "sharp",
-      "unrs-resolver"
-    ]
-  }
+  "packageManager": "pnpm@10.34.4"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,4 @@
+allowBuilds:
+  esbuild: true
+  sharp: true
+  unrs-resolver: true


### PR DESCRIPTION
## Summary

- Removes the `pnpm.onlyBuiltDependencies` field from `package.json`
- Adds a new `pnpm-workspace.yaml` file with an `allowBuilds` configuration for `esbuild`, `sharp`, and `unrs-resolver`

This change follows the newer pnpm behavior where `pnpm approve-builds` writes build approval config to `pnpm-workspace.yaml` instead of `package.json`.

Closes #641