### PR TITLE
Bump Node.js to version 24.18.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   "devEngines": {
     "runtime": {
       "name": "node",
-      "version": "^24.17.0",
+      "version": "^24.18.0",
       "onFail": "download"
     }
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -97,7 +97,7 @@ importers:
         specifier: ^4.0.0
         version: 4.0.0
       node:
-        specifier: runtime:^24.17.0
+        specifier: runtime:^24.18.0
         version: runtime:24.18.0
       pagefind:
         specifier: ^1.4.0


### PR DESCRIPTION
This pull request bumps Node.js to version [24.18.0](https://github.com/nodejs/node/releases/tag/v24.18.0).